### PR TITLE
Make x and y of IpcFoodInfo and IpcSegmentInfo useful

### DIFF
--- a/docker4bots/spn_cpp_base/spn_cpp_framework/src/ipc_format.h
+++ b/docker4bots/spn_cpp_base/spn_cpp_framework/src/ipc_format.h
@@ -64,8 +64,8 @@ struct IpcServerConfig {
  * IPC representation of a food particle.
  */
 struct IpcFoodInfo {
-	ipc_real_t x;      //!< Relative position X in world orientation
-	ipc_real_t y;      //!< Relative position Y in world orientation
+	ipc_real_t x;      //!< Relative position X relative to your heading
+	ipc_real_t y;      //!< Relative position Y relative to your heading
 	ipc_real_t val;    //!< Food value
 	ipc_real_t dir;    //!< Direction angle relative to your heading (range -π to +π)
 	ipc_real_t dist;   //!< Distance measured from the center of your head
@@ -83,8 +83,8 @@ struct IpcBotInfo {
  * IPC representation of a snake segment.
  */
 struct IpcSegmentInfo {
-	ipc_real_t x;       //!< Relative position X in world orientation
-	ipc_real_t y;       //!< Relative position Y in world orientation
+	ipc_real_t x;       //!< Relative position X relative to your heading
+	ipc_real_t y;       //!< Relative position Y relative to your heading
 	ipc_real_t r;       //!< Segment radius
 	ipc_real_t dir;     //!< Direction angle relative to your heading (range -π to +π)
 	ipc_real_t dist;    //!< Distance between the center of your head and the segment's center

--- a/src/DockerBot.cpp
+++ b/src/DockerBot.cpp
@@ -220,8 +220,8 @@ void DockerBot::fillSharedMemory(void)
 			auto distance = relPos.norm();
 			if (distance>radius) { continue; }
 
-			m_shm->foodInfo[idx].x = relPos.x();
-			m_shm->foodInfo[idx].y = relPos.y();
+			m_shm->foodInfo[idx].x = distance * cos(direction);
+			m_shm->foodInfo[idx].y = distance * sin(direction);
 			m_shm->foodInfo[idx].val = food.getValue();
 			m_shm->foodInfo[idx].dir = direction;
 			m_shm->foodInfo[idx].dist = distance;
@@ -263,8 +263,8 @@ void DockerBot::fillSharedMemory(void)
 		if (direction < -M_PI) { direction += 2*M_PI; }
 		if (direction >  M_PI) { direction -= 2*M_PI; }
 
-		m_shm->segmentInfo[idx].x = relPos.x();
-		m_shm->segmentInfo[idx].y = relPos.y();
+		m_shm->segmentInfo[idx].x = distance * cos(direction);
+		m_shm->segmentInfo[idx].y = distance * sin(direction);
 		m_shm->segmentInfo[idx].r = segmentRadius;
 		m_shm->segmentInfo[idx].dir = direction;
 		m_shm->segmentInfo[idx].dist = distance;


### PR DESCRIPTION
Before this change, x and y were given in "world orientation",
meaning that they were translated to a coordinate system where
the origin is the bot's head, but the x and y axes are parallel to
the world coordinate's axes.

This basically rendered x and y useless, because nothing else is given
in that coordinate system, and the bot has no idea about its own rotation.

Modify the values of x and y (i.e. rotate them) to match the coordinate
system of all other values, i.e. where the y axis is the bot's direction.

Note: I didn't actually validate my changes, it's more of a discussion starter.