### PR TITLE
Add paranthesis around the /spnshm mount argument to docker

### DIFF
--- a/docker4bots/2_run_debug_container.sh
+++ b/docker4bots/2_run_debug_container.sh
@@ -33,7 +33,7 @@ BOT_DATADIR="$SPN_DATA_HOSTDIR/${BOT_NAME}_$VERSION_ID"
 exec docker run -d --rm \
 	$DOCKER_RUN_ARGS \
 	-v "$BOT_DATADIR:/spndata:ro" \
-	-v $SPN_SHM_HOSTDIR/$BOT_NAME:/spnshm \
+	-v "$SPN_SHM_HOSTDIR/$BOT_NAME:/spnshm" \
 	--name "$CONTAINER_NAME" \
 	--entrypoint=/bin/bash -it \
 	spn_cpp_base:latest run

--- a/docker4bots/2_run_spn_cpp_bot.sh
+++ b/docker4bots/2_run_spn_cpp_bot.sh
@@ -33,6 +33,6 @@ BOT_DATADIR="$SPN_DATA_HOSTDIR/${BOT_NAME}_$VERSION_ID"
 exec docker run -d --rm \
 	$DOCKER_RUN_ARGS \
 	-v "$BOT_DATADIR:/spndata:ro" \
-	-v $SPN_SHM_HOSTDIR/$BOT_NAME:/spnshm \
+	-v "$SPN_SHM_HOSTDIR/$BOT_NAME:/spnshm" \
 	--name "$CONTAINER_NAME" \
 	spn_cpp_base:latest run


### PR DESCRIPTION
Mainly this prevents command injection using BOT_NAME. This shouldnt be a real problem though, as the BOT_NAME is already sanitized in DockerBot.cpp. Just to make sure.