### PR TITLE
rust: Formatting, fix clippy warnings and improve error handling

### DIFF
--- a/docker4bots/spn_rust_base/Dockerfile
+++ b/docker4bots/spn_rust_base/Dockerfile
@@ -1,19 +1,18 @@
-FROM rust:1.57-slim
+FROM rust:1.66-slim
 
-#RUN apk add --no-cache rust cargo
+# Create the shared memory directory and add spnbot user
+RUN mkdir /spnshm && \
+    addgroup --system spnbot && adduser --system --uid 1337 --home /spnbot --shell /bin/sh --ingroup spnbot spnbot
+USER spnbot
 
-RUN addgroup --system spnbot && adduser --system --uid 1337 --home /spnbot --shell /bin/sh --ingroup spnbot spnbot
+COPY --chown=spnbot:spnbot bot_wrapper.sh /
+COPY --chown=spnbot:spnbot spn_rust_framework/ /spnbot/spn_rust_framework
 
-ADD bot_wrapper.sh /
+# Pre-build framework to reduce compile times
+RUN cd /spnbot/spn_rust_framework && \
+    ./build.sh
 
-ADD spn_rust_framework/ /spnbot/spn_rust_framework
-
-# pre-build framework, hand it over to the spnbot user and create the shared memory directory
-# (all in one step to save layers)
-RUN cd /spnbot/spn_rust_framework && ./build.sh && chown -R spnbot /spnbot && mkdir /spnshm
 VOLUME /spnshm
 VOLUME /spndata
-
-USER spnbot
 
 ENTRYPOINT ["/bot_wrapper.sh"]

--- a/docker4bots/spn_rust_base/spn_rust_framework/src/api.rs
+++ b/docker4bots/spn_rust_base/spn_rust_framework/src/api.rs
@@ -3,8 +3,8 @@
 extern crate memmap2;
 
 use std::fs::OpenOptions;
-use std::result::Result;
 use std::mem::{size_of, transmute};
+use std::result::Result;
 
 use memmap2::MmapRaw;
 
@@ -21,179 +21,170 @@ use ipc::IpcSharedMemory;
  * Please note that most methods return direct references to the shared memory structures. These
  * are specified and documentet in the ipc module.
  */
-pub struct Api<'a>
-{
-	#[allow(dead_code)]
-	mmap: MmapRaw,
-	ipcdata: &'a mut IpcSharedMemory,
+pub struct Api<'a> {
+    #[allow(dead_code)]
+    mmap: MmapRaw,
+    ipcdata: &'a mut IpcSharedMemory,
 }
 
-impl<'i> Api<'i>
-{
-	/**
-	 * Construct a new Api instance from the given shared memory file.
-	 *
-	 * This function is used internally by the bot framework. Do not worry about it.
-	 */
-	pub fn new<'a>(shmfilename: &'a str) -> Result<Api<'a>, String>
-	{
-		// open and map the shared memory
-		let file = OpenOptions::new()
-			.read(true)
-			.write(true)
-			.open(shmfilename).unwrap();
+impl<'i> Api<'i> {
+    /**
+     * Construct a new Api instance from the given shared memory file.
+     *
+     * This function is used internally by the bot framework. Do not worry about it.
+     */
+    pub fn new<'a>(shmfilename: &'a str) -> Result<Api<'a>, String> {
+        // open and map the shared memory
+        let file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(shmfilename)
+            .unwrap();
 
-		let mmap = MmapRaw::map_raw(&file).unwrap();
+        let mmap = MmapRaw::map_raw(&file).unwrap();
 
-		// check the size of the shared memory. It must be large enough to hold one complete
-		// IpcSharedMemory structure.
-		if mmap.len() < size_of::<ipc::IpcSharedMemory>() {
-			return Err(format!("Shared memory contains only {} bytes where {} bytes are required.",
-			       mmap.len(), size_of::<ipc::IpcSharedMemory>()));
-		}
+        // check the size of the shared memory. It must be large enough to hold one complete
+        // IpcSharedMemory structure.
+        if mmap.len() < size_of::<ipc::IpcSharedMemory>() {
+            return Err(format!(
+                "Shared memory contains only {} bytes where {} bytes are required.",
+                mmap.len(),
+                size_of::<ipc::IpcSharedMemory>()
+            ));
+        }
 
-		// map the shared memory to a IpcSharedMemory structure.
-		let ipcdata = unsafe {
-			&mut *transmute::<*mut u8, *mut ipc::IpcSharedMemory>(mmap.as_mut_ptr())
-		};
+        // map the shared memory to a IpcSharedMemory structure.
+        let ipcdata =
+            unsafe { &mut *transmute::<*mut u8, *mut ipc::IpcSharedMemory>(mmap.as_mut_ptr()) };
 
-		Ok(Api{
-			mmap: mmap,
-			ipcdata: ipcdata
-		})
-	}
+        Ok(Api {
+            mmap: mmap,
+            ipcdata: ipcdata,
+        })
+    }
 
-	/**
-	 * Get a reference to the server config data.
-	 *
-	 * The returned structure contains information about the server
-	 * configuration and static world information.
-	 */
-	pub fn get_server_config(&self) -> &ipc::IpcServerConfig
-	{
-		return &self.ipcdata.server_config;
-	}
+    /**
+     * Get a reference to the server config data.
+     *
+     * The returned structure contains information about the server
+     * configuration and static world information.
+     */
+    pub fn get_server_config(&self) -> &ipc::IpcServerConfig {
+        return &self.ipcdata.server_config;
+    }
 
-	/**
-	 * Get a pointer to the self information.
-	 *
-	 * The returned structure contains information about your snake and
-	 * parameters of the world.
-	 */
-	pub fn get_self_info(&self) -> &ipc::IpcSelfInfo
-	{
-		return &self.ipcdata.self_info;
-	}
+    /**
+     * Get a pointer to the self information.
+     *
+     * The returned structure contains information about your snake and
+     * parameters of the world.
+     */
+    pub fn get_self_info(&self) -> &ipc::IpcSelfInfo {
+        return &self.ipcdata.self_info;
+    }
 
-	/**
-	 * Get a reference to the array of food items around your snake’s head.
-	 *
-	 * The items are sorted by the distance from your snake’s head, so the first entry is the
-	 * closest item.
-	 *
-	 * Only the valid entries in the shared memory are returned.
-	 */
-	pub fn get_food(&self) -> &[ipc::IpcFoodInfo]
-	{
-		&self.ipcdata.food_info[0 .. self.ipcdata.food_count as usize]
-	}
+    /**
+     * Get a reference to the array of food items around your snake’s head.
+     *
+     * The items are sorted by the distance from your snake’s head, so the first entry is the
+     * closest item.
+     *
+     * Only the valid entries in the shared memory are returned.
+     */
+    pub fn get_food(&self) -> &[ipc::IpcFoodInfo] {
+        &self.ipcdata.food_info[0..self.ipcdata.food_count as usize]
+    }
 
-	/**
-	 * Get a reference to the array of snake segments around your snake’s head.
-	 *
-	 * The items are sorted by the distance from your snake’s head, so the first entry is the
-	 * closest item.
-	 *
-	 * Only the valid entries in the shared memory are returned.
-	 */
-	pub fn get_segments(&self) -> &[ipc::IpcSegmentInfo]
-	{
-		&self.ipcdata.segment_info[0 .. self.ipcdata.segment_count as usize]
-	}
+    /**
+     * Get a reference to the array of snake segments around your snake’s head.
+     *
+     * The items are sorted by the distance from your snake’s head, so the first entry is the
+     * closest item.
+     *
+     * Only the valid entries in the shared memory are returned.
+     */
+    pub fn get_segments(&self) -> &[ipc::IpcSegmentInfo] {
+        &self.ipcdata.segment_info[0..self.ipcdata.segment_count as usize]
+    }
 
-	/**
-	 * Get a reference to the array of bot information structures.
-	 *
-	 * Only the valid entries in the shared memory are returned.
-	 */
-	pub fn get_bot_info(&self) -> &[ipc::IpcBotInfo]
-	{
-		&self.ipcdata.bot_info[0 .. self.ipcdata.bot_count as usize]
-	}
+    /**
+     * Get a reference to the array of bot information structures.
+     *
+     * Only the valid entries in the shared memory are returned.
+     */
+    pub fn get_bot_info(&self) -> &[ipc::IpcBotInfo] {
+        &self.ipcdata.bot_info[0..self.ipcdata.bot_count as usize]
+    }
 
-	/**
-	 * Remove all color entries from the shared memory.
-	 *
-	 * This must be called in your [`crate::usercode::init()`] function to remove the default color
-	 * in case you want to set your own.
-	 */
-	pub fn clear_colors(&mut self)
-	{
-		self.ipcdata.color_count = 0;
-	}
+    /**
+     * Remove all color entries from the shared memory.
+     *
+     * This must be called in your [`crate::usercode::init()`] function to remove the default color
+     * in case you want to set your own.
+     */
+    pub fn clear_colors(&mut self) {
+        self.ipcdata.color_count = 0;
+    }
 
-	/**
-	 * Add a color to your snake’s color sequence.
-	 *
-	 * Call this multiple times from [`crate::usercode::init()`] to set up your snake’s colors. The
-	 * provided sequence will be repeated along your snake if it has more sequence than colors were
-	 * specified. You can set up to [`ipc::IPC_COLOR_MAX_COUNT`] colors.
-	 */
-	pub fn add_color(&mut self, r: u8, g: u8, b: u8)
-	{
-		self.ipcdata.colors[self.ipcdata.color_count as usize] = ipc::IpcColor{r, g, b};
-		self.ipcdata.color_count += 1;
-	}
+    /**
+     * Add a color to your snake’s color sequence.
+     *
+     * Call this multiple times from [`crate::usercode::init()`] to set up your snake’s colors. The
+     * provided sequence will be repeated along your snake if it has more sequence than colors were
+     * specified. You can set up to [`ipc::IPC_COLOR_MAX_COUNT`] colors.
+     */
+    pub fn add_color(&mut self, r: u8, g: u8, b: u8) {
+        self.ipcdata.colors[self.ipcdata.color_count as usize] = ipc::IpcColor { r, g, b };
+        self.ipcdata.color_count += 1;
+    }
 
-	/**
-	 * Get a reference to the persistent memory.
-	 *
-	 * You can use persistent memory to remember things across multiple lives
-	 * of your snake. It is saved after your snake dies (even when your code
-	 * crashes) and restored when it respawns.
-	 *
-	 * Note that the size this memory is very limited (given by the
-	 * [`ipc::IPC_PERSISTENT_MAX_BYTES`] constant). Use it wisely.
-	 */
-	pub fn get_persistent_memory(&mut self) -> &mut[u8]
-	{
-		return &mut self.ipcdata.persistent_data;
-	}
+    /**
+     * Get a reference to the persistent memory.
+     *
+     * You can use persistent memory to remember things across multiple lives
+     * of your snake. It is saved after your snake dies (even when your code
+     * crashes) and restored when it respawns.
+     *
+     * Note that the size this memory is very limited (given by the
+     * [`ipc::IPC_PERSISTENT_MAX_BYTES`] constant). Use it wisely.
+     */
+    pub fn get_persistent_memory(&mut self) -> &mut [u8] {
+        return &mut self.ipcdata.persistent_data;
+    }
 
-	/**
-	 * Send a log message.
-	 *
-	 * These messages will appear on the web interface and in the World update
-	 * stream when you provide your viewer key to the server.
-	 *
-	 * Rate limiting is enforced by the gameserver, so messages are dropped
-	 * when you send too many of them.
-	 */
-	pub fn log(&mut self, text: &str) -> bool
-	{
-		// determine length of stored data
-		let startpos;
+    /**
+     * Send a log message.
+     *
+     * These messages will appear on the web interface and in the World update
+     * stream when you provide your viewer key to the server.
+     *
+     * Rate limiting is enforced by the gameserver, so messages are dropped
+     * when you send too many of them.
+     */
+    pub fn log(&mut self, text: &str) -> bool {
+        // determine length of stored data
+        let startpos;
 
-		match self.ipcdata.log_data.iter().position(|&b| b == b'\0') {
-			Some(n) => startpos = n,
-			None => return false // log memory is not properly initialized or corrupt
-		}
+        match self.ipcdata.log_data.iter().position(|&b| b == b'\0') {
+            Some(n) => startpos = n,
+            None => return false, // log memory is not properly initialized or corrupt
+        }
 
-		if startpos + text.len() + 2 > self.ipcdata.log_data.len() {
-			// log memory too full to append this message + newline + nullbyte
-			return false;
-		}
+        if startpos + text.len() + 2 > self.ipcdata.log_data.len() {
+            // log memory too full to append this message + newline + nullbyte
+            return false;
+        }
 
-		let mut pos = startpos;
-		for byte in text.as_bytes() {
-			self.ipcdata.log_data[pos] = *byte;
-			pos += 1;
-		}
+        let mut pos = startpos;
+        for byte in text.as_bytes() {
+            self.ipcdata.log_data[pos] = *byte;
+            pos += 1;
+        }
 
-		self.ipcdata.log_data[pos] = b'\n';
-		pos += 1;
-		self.ipcdata.log_data[pos] = b'\0';
+        self.ipcdata.log_data[pos] = b'\n';
+        pos += 1;
+        self.ipcdata.log_data[pos] = b'\0';
 
-		return true;
-	}
+        return true;
+    }
 }

--- a/docker4bots/spn_rust_base/spn_rust_framework/src/api.rs
+++ b/docker4bots/spn_rust_base/spn_rust_framework/src/api.rs
@@ -33,7 +33,7 @@ impl<'i> Api<'i> {
      *
      * This function is used internally by the bot framework. Do not worry about it.
      */
-    pub fn new<'a>(shmfilename: &'a str) -> Result<Api<'a>, String> {
+    pub fn new(shmfilename: &str) -> Result<Api, String> {
         // open and map the shared memory
         let file = OpenOptions::new()
             .read(true)
@@ -58,8 +58,8 @@ impl<'i> Api<'i> {
             unsafe { &mut *transmute::<*mut u8, *mut ipc::IpcSharedMemory>(mmap.as_mut_ptr()) };
 
         Ok(Api {
-            mmap: mmap,
-            ipcdata: ipcdata,
+            mmap,
+            ipcdata,
         })
     }
 
@@ -70,7 +70,7 @@ impl<'i> Api<'i> {
      * configuration and static world information.
      */
     pub fn get_server_config(&self) -> &ipc::IpcServerConfig {
-        return &self.ipcdata.server_config;
+        &self.ipcdata.server_config
     }
 
     /**
@@ -80,7 +80,7 @@ impl<'i> Api<'i> {
      * parameters of the world.
      */
     pub fn get_self_info(&self) -> &ipc::IpcSelfInfo {
-        return &self.ipcdata.self_info;
+        &self.ipcdata.self_info
     }
 
     /**
@@ -149,7 +149,7 @@ impl<'i> Api<'i> {
      * [`ipc::IPC_PERSISTENT_MAX_BYTES`] constant). Use it wisely.
      */
     pub fn get_persistent_memory(&mut self) -> &mut [u8] {
-        return &mut self.ipcdata.persistent_data;
+        &mut self.ipcdata.persistent_data
     }
 
     /**
@@ -163,12 +163,10 @@ impl<'i> Api<'i> {
      */
     pub fn log(&mut self, text: &str) -> bool {
         // determine length of stored data
-        let startpos;
-
-        match self.ipcdata.log_data.iter().position(|&b| b == b'\0') {
-            Some(n) => startpos = n,
+        let startpos = match self.ipcdata.log_data.iter().position(|&b| b == b'\0') {
+            Some(n) => n,
             None => return false, // log memory is not properly initialized or corrupt
-        }
+        };
 
         if startpos + text.len() + 2 > self.ipcdata.log_data.len() {
             // log memory too full to append this message + newline + nullbyte
@@ -185,6 +183,6 @@ impl<'i> Api<'i> {
         pos += 1;
         self.ipcdata.log_data[pos] = b'\0';
 
-        return true;
+        true
     }
 }

--- a/docker4bots/spn_rust_base/spn_rust_framework/src/api.rs
+++ b/docker4bots/spn_rust_base/spn_rust_framework/src/api.rs
@@ -169,18 +169,12 @@ impl<'i> Api<'i> {
             .ok_or_else(|| "Log memory is not properly initialized or corrupt".to_string())?;
 
         if startpos + text.len() + 2 > self.ipcdata.log_data.len() {
-            return Err("Rate limit reached (Log memory too full to append this message + newline + nullbyte)".to_owned());
+            return Err("Log memory too full to append the log message".to_owned());
         }
 
-        let mut pos = startpos;
-        for byte in text.as_bytes() {
-            self.ipcdata.log_data[pos] = *byte;
-            pos += 1;
-        }
-
-        self.ipcdata.log_data[pos] = b'\n';
-        pos += 1;
-        self.ipcdata.log_data[pos] = b'\0';
+        self.ipcdata.log_data[startpos..startpos + text.len()].copy_from_slice(text.as_bytes());
+        self.ipcdata.log_data[startpos + text.len()] = b'\n';
+        self.ipcdata.log_data[startpos + text.len() + 1] = b'\0';
 
         Ok(())
     }

--- a/docker4bots/spn_rust_base/spn_rust_framework/src/api/ipc.rs
+++ b/docker4bots/spn_rust_base/spn_rust_framework/src/api/ipc.rs
@@ -9,31 +9,31 @@ type IpcGuid = u64;
 #[repr(C)]
 #[repr(align(4))]
 pub struct IpcSelfInfo {
-	/// Radius of your snake's segments
-	pub segment_radius                 : IpcReal,
-	/// Your Snake's current mass
-	pub mass                           : IpcReal,
-	/// Radius around your snake's head in which you can see food and segments
-	pub sight_radius                   : IpcReal,
-	/// Radius around your snake's head in which food is consumed.
-	pub consume_radius                 : IpcReal,
+    /// Radius of your snake's segments
+    pub segment_radius: IpcReal,
+    /// Your Snake's current mass
+    pub mass: IpcReal,
+    /// Radius around your snake's head in which you can see food and segments
+    pub sight_radius: IpcReal,
+    /// Radius around your snake's head in which food is consumed.
+    pub consume_radius: IpcReal,
 
-	/// Frame number when your snake was spawned
-	pub start_frame                    : u32,
-	/// Current frame number
-	pub current_frame                  : u32,
+    /// Frame number when your snake was spawned
+    pub start_frame: u32,
+    /// Current frame number
+    pub current_frame: u32,
 
-	/// Distance per step
-	pub speed                          : IpcReal,
-	/// Maximum direction change in this step
-	pub max_step_angle                 : IpcReal,
+    /// Distance per step
+    pub speed: IpcReal,
+    /// Maximum direction change in this step
+    pub max_step_angle: IpcReal,
 
-	/// Amount of "naturally" spawned food your snake consumed
-	pub consumed_natural_food          : IpcReal,
-	/// Amount of food you consumed and that was created from snakes you killed
-	pub consumed_food_hunted_by_self   : IpcReal,
-	/// Amount of food you consumed and that was created from snakes others killed (carrion)
-	pub consumed_food_hunted_by_others : IpcReal,
+    /// Amount of "naturally" spawned food your snake consumed
+    pub consumed_natural_food: IpcReal,
+    /// Amount of food you consumed and that was created from snakes you killed
+    pub consumed_food_hunted_by_self: IpcReal,
+    /// Amount of food you consumed and that was created from snakes others killed (carrion)
+    pub consumed_food_hunted_by_others: IpcReal,
 }
 
 /**
@@ -45,42 +45,42 @@ pub struct IpcSelfInfo {
 #[repr(C)]
 #[repr(align(4))]
 pub struct IpcServerConfig {
-	/// Number of steps a snake moves per frame while boosting
-	pub snake_boost_steps: u32,
-	/// Multiplied with your segment radius to determine the inner turn radius
-	pub snake_turn_radius_factor: IpcReal,
+    /// Number of steps a snake moves per frame while boosting
+    pub snake_boost_steps: u32,
+    /// Multiplied with your segment radius to determine the inner turn radius
+    pub snake_turn_radius_factor: IpcReal,
 
-	/// Pull-together factor (determines how fast segments move to the center of a loop)
-	pub snake_pull_factor: IpcReal,
+    /// Pull-together factor (determines how fast segments move to the center of a loop)
+    pub snake_pull_factor: IpcReal,
 
-	/// how much of a snake's mass is converted to food when it dies
-	pub snake_conversion_factor: IpcReal,
+    /// how much of a snake's mass is converted to food when it dies
+    pub snake_conversion_factor: IpcReal,
 
-	/// segment distance = (mass * factor)^exponent
-	pub snake_segment_distance_factor: IpcReal,
-	/// segment distance = (mass * factor)^exponent
-	pub snake_segment_distance_exponent: IpcReal,
+    /// segment distance = (mass * factor)^exponent
+    pub snake_segment_distance_factor: IpcReal,
+    /// segment distance = (mass * factor)^exponent
+    pub snake_segment_distance_exponent: IpcReal,
 
-	/// consume range multiplier (multiplied with segment radius)
-	pub snake_consume_range: IpcReal,
+    /// consume range multiplier (multiplied with segment radius)
+    pub snake_consume_range: IpcReal,
 
-	/// Multiplied with the snakes mass to determine how much mass is lost per frame while boosting
-	pub snake_boost_loss_factor: IpcReal,
-	/// This part of your mass is dropped every frame (to limit snake growth)
-	pub snake_survival_loss_factor: IpcReal,
+    /// Multiplied with the snakes mass to determine how much mass is lost per frame while boosting
+    pub snake_boost_loss_factor: IpcReal,
+    /// This part of your mass is dropped every frame (to limit snake growth)
+    pub snake_survival_loss_factor: IpcReal,
 
-	/// Mass below which a snake dies through starvation
-	pub snake_self_kill_mass_threshold: IpcReal,
+    /// Mass below which a snake dies through starvation
+    pub snake_self_kill_mass_threshold: IpcReal,
 
-	/// Food decays by this value each frame
-	pub food_decay_step: IpcReal,
+    /// Food decays by this value each frame
+    pub food_decay_step: IpcReal,
 
-	/// How many log messages you can send per frame
-	pub log_credits_per_frame: IpcReal,
-	/// How many log messages you can send right after startup
-	pub log_initial_credits: IpcReal,
-	/// You can send at most this many messages in a row
-	pub log_max_credits: IpcReal,
+    /// How many log messages you can send per frame
+    pub log_credits_per_frame: IpcReal,
+    /// How many log messages you can send right after startup
+    pub log_initial_credits: IpcReal,
+    /// You can send at most this many messages in a row
+    pub log_max_credits: IpcReal,
 }
 
 /**
@@ -89,16 +89,16 @@ pub struct IpcServerConfig {
 #[repr(C)]
 #[repr(align(4))]
 pub struct IpcFoodInfo {
-	/// Relative position X in world orientation
-	pub x: IpcReal,
-	/// Relative position Y in world orientation
-	pub y: IpcReal,
-	/// Food value
-	pub val: IpcReal,
-	/// Direction angle relative to your heading (range -π to +π)
-	pub dir: IpcReal,
-	/// Distance measured from the center of your head
-	pub dist: IpcReal,
+    /// Relative position X in world orientation
+    pub x: IpcReal,
+    /// Relative position Y in world orientation
+    pub y: IpcReal,
+    /// Food value
+    pub val: IpcReal,
+    /// Direction angle relative to your heading (range -π to +π)
+    pub dir: IpcReal,
+    /// Distance measured from the center of your head
+    pub dist: IpcReal,
 }
 
 /**
@@ -107,10 +107,10 @@ pub struct IpcFoodInfo {
 #[repr(C)]
 #[repr(align(4))]
 pub struct IpcBotInfo {
-	/// Bot ID
-	pub bot_id: IpcGuid,
-	/// Bot name (the beginning of it, at least)
-	pub bot_name: [u8; 64],
+    /// Bot ID
+    pub bot_id: IpcGuid,
+    /// Bot name (the beginning of it, at least)
+    pub bot_name: [u8; 64],
 }
 
 /**
@@ -119,22 +119,22 @@ pub struct IpcBotInfo {
 #[repr(C)]
 #[repr(align(4))]
 pub struct IpcSegmentInfo {
-	/// Relative position X in world orientation
-	pub x: IpcReal,
-	/// Relative position Y in world orientation
-	pub y: IpcReal,
-	/// Segment radius
-	pub r: IpcReal,
-	/// Direction angle relative to your heading (range -π to +π)
-	pub dir: IpcReal,
-	/// Distance between the center of your head and the segment's center
-	pub dist: IpcReal,
-	/// Segment number starting from head (idx == 0)
-	pub idx: u32,
-	/// Bot ID
-	pub bot_id: IpcGuid,
-	/// True if this segment belongs to ones own snake
-	pub is_self: bool,
+    /// Relative position X in world orientation
+    pub x: IpcReal,
+    /// Relative position Y in world orientation
+    pub y: IpcReal,
+    /// Segment radius
+    pub r: IpcReal,
+    /// Direction angle relative to your heading (range -π to +π)
+    pub dir: IpcReal,
+    /// Distance between the center of your head and the segment's center
+    pub dist: IpcReal,
+    /// Segment number starting from head (idx == 0)
+    pub idx: u32,
+    /// Bot ID
+    pub bot_id: IpcGuid,
+    /// True if this segment belongs to ones own snake
+    pub is_self: bool,
 }
 
 /**
@@ -143,21 +143,21 @@ pub struct IpcSegmentInfo {
 #[repr(C)]
 #[repr(align(4))]
 pub struct IpcColor {
-	/// Red channel (0-255)
-	pub r: u8,
-	/// Green channel (0-255)
-	pub g: u8,
-	/// Blue channel (0-255)
-	pub b: u8,
+    /// Red channel (0-255)
+    pub r: u8,
+    /// Green channel (0-255)
+    pub g: u8,
+    /// Blue channel (0-255)
+    pub b: u8,
 }
 
-pub const IPC_FOOD_MAX_BYTES: usize = 1 * 1024*1024;
+pub const IPC_FOOD_MAX_BYTES: usize = 1 * 1024 * 1024;
 pub const IPC_FOOD_MAX_COUNT: usize = IPC_FOOD_MAX_BYTES / size_of::<IpcFoodInfo>();
 
 pub const IPC_BOT_MAX_COUNT: usize = 1024;
 pub const IPC_BOT_MAX_BYTES: usize = IPC_BOT_MAX_COUNT * size_of::<IpcBotInfo>();
 
-pub const IPC_SEGMENT_MAX_BYTES: usize = 1 * 1024*1024;
+pub const IPC_SEGMENT_MAX_BYTES: usize = 1 * 1024 * 1024;
 pub const IPC_SEGMENT_MAX_COUNT: usize = IPC_SEGMENT_MAX_BYTES / size_of::<IpcSegmentInfo>();
 
 pub const IPC_COLOR_MAX_COUNT: usize = 1024;
@@ -177,42 +177,42 @@ pub const IPC_PERSISTENT_MAX_BYTES: usize = 4096;
 #[repr(C)]
 #[repr(align(4))]
 pub struct IpcSharedMemory {
-	/// Information about the world and server configuration.
-	pub server_config: IpcServerConfig,
+    /// Information about the world and server configuration.
+    pub server_config: IpcServerConfig,
 
-	/// Information about your snake (updated every frame).
-	pub self_info: IpcSelfInfo,
+    /// Information about your snake (updated every frame).
+    pub self_info: IpcSelfInfo,
 
-	/// Number of items used in foodInfo.
-	pub food_count: u32,
-	/// List of food items seen by the snake.
-	pub food_info: [IpcFoodInfo; IPC_FOOD_MAX_COUNT],
+    /// Number of items used in foodInfo.
+    pub food_count: u32,
+    /// List of food items seen by the snake.
+    pub food_info: [IpcFoodInfo; IPC_FOOD_MAX_COUNT],
 
-	/// Number of items used in botInfo.
-	pub bot_count: u32,
-	/// List of bots related to segments in segmentInfo.
-	pub bot_info: [IpcBotInfo; IPC_BOT_MAX_COUNT],
+    /// Number of items used in botInfo.
+    pub bot_count: u32,
+    /// List of bots related to segments in segmentInfo.
+    pub bot_info: [IpcBotInfo; IPC_BOT_MAX_COUNT],
 
-	/// Number of items used in segmentInfo.
-	pub segment_count: u32,
-	/// List of segments seen by the snake.
-	pub segment_info: [IpcSegmentInfo; IPC_SEGMENT_MAX_COUNT],
+    /// Number of items used in segmentInfo.
+    pub segment_count: u32,
+    /// List of segments seen by the snake.
+    pub segment_info: [IpcSegmentInfo; IPC_SEGMENT_MAX_COUNT],
 
-	/// Number of items used in colors.
-	pub color_count: u32,
-	/// Colors to set for this snake.
-	pub colors: [IpcColor; IPC_COLOR_MAX_COUNT],
+    /// Number of items used in colors.
+    pub color_count: u32,
+    /// Colors to set for this snake.
+    pub colors: [IpcColor; IPC_COLOR_MAX_COUNT],
 
-	/// Log data for the current frame. May contain multiple lines.
-	pub log_data: [u8; IPC_LOG_MAX_BYTES],
+    /// Log data for the current frame. May contain multiple lines.
+    pub log_data: [u8; IPC_LOG_MAX_BYTES],
 
-	/// Select a face for your snake (not used yet).
-	pub face_id: u32,
-	/// Select a dog tag for your snake (not used yet).
-	pub dog_tag_id: u32,
+    /// Select a face for your snake (not used yet).
+    pub face_id: u32,
+    /// Select a dog tag for your snake (not used yet).
+    pub dog_tag_id: u32,
 
-	/// Persistent data: will be saved after your snake dies and restored when it respawns
-	pub persistent_data: [u8; IPC_PERSISTENT_MAX_BYTES],
+    /// Persistent data: will be saved after your snake dies and restored when it respawns
+    pub persistent_data: [u8; IPC_PERSISTENT_MAX_BYTES],
 }
 
 pub const IPC_SHARED_MEMORY_BYTES: usize = size_of::<IpcSharedMemory>();
@@ -225,10 +225,10 @@ pub const IPC_SHARED_MEMORY_BYTES: usize = size_of::<IpcSharedMemory>();
 #[repr(align(4))]
 #[derive(FromPrimitive, ToPrimitive)]
 pub enum IpcRequestType {
-	/// Bot initialization request. Sent once after bot startup.
-	Init = 0,
-	/// Bot step request. Sent every frame.
-	Step = 1
+    /// Bot initialization request. Sent once after bot startup.
+    Init = 0,
+    /// Bot step request. Sent every frame.
+    Step = 1,
 }
 
 /**
@@ -239,7 +239,7 @@ pub enum IpcRequestType {
 #[repr(C)]
 #[repr(align(4))]
 pub struct IpcRequest {
-	pub request_type: IpcRequestType
+    pub request_type: IpcRequestType,
 }
 
 /**
@@ -249,8 +249,8 @@ pub struct IpcRequest {
 #[repr(align(4))]
 #[derive(FromPrimitive, ToPrimitive)]
 pub enum IpcResponseType {
-	Ok = 0,
-	Error = 1
+    Ok = 0,
+    Error = 1,
 }
 
 /**
@@ -260,10 +260,10 @@ pub enum IpcResponseType {
 #[repr(align(4))]
 #[derive(Clone, Copy)]
 pub struct IpcStepResponse {
-	/// Direction change in this frame (radians, -π to +π).
-	pub delta_angle: IpcReal,
-	/// Set to true to boost.
-	pub boost: bool,
+    /// Direction change in this frame (radians, -π to +π).
+    pub delta_angle: IpcReal,
+    /// Set to true to boost.
+    pub boost: bool,
 }
 
 // FIXME! This should actually be a union, which makes things complicated in Rust. As there is
@@ -272,7 +272,7 @@ pub struct IpcStepResponse {
 #[repr(C)]
 #[repr(align(4))]
 pub union ResponseData {
-	pub step: IpcStepResponse
+    pub step: IpcStepResponse,
 }
 
 /**
@@ -283,7 +283,7 @@ pub union ResponseData {
 #[repr(C)]
 #[repr(align(4))]
 pub struct IpcResponse {
-	pub response_type: IpcResponseType,
+    pub response_type: IpcResponseType,
 
-	pub data: ResponseData
+    pub data: ResponseData,
 }

--- a/docker4bots/spn_rust_base/spn_rust_framework/src/api/ipc.rs
+++ b/docker4bots/spn_rust_base/spn_rust_framework/src/api/ipc.rs
@@ -151,13 +151,13 @@ pub struct IpcColor {
     pub b: u8,
 }
 
-pub const IPC_FOOD_MAX_BYTES: usize = 1 * 1024 * 1024;
+pub const IPC_FOOD_MAX_BYTES: usize = 1024 * 1024;
 pub const IPC_FOOD_MAX_COUNT: usize = IPC_FOOD_MAX_BYTES / size_of::<IpcFoodInfo>();
 
 pub const IPC_BOT_MAX_COUNT: usize = 1024;
 pub const IPC_BOT_MAX_BYTES: usize = IPC_BOT_MAX_COUNT * size_of::<IpcBotInfo>();
 
-pub const IPC_SEGMENT_MAX_BYTES: usize = 1 * 1024 * 1024;
+pub const IPC_SEGMENT_MAX_BYTES: usize = 1024 * 1024;
 pub const IPC_SEGMENT_MAX_COUNT: usize = IPC_SEGMENT_MAX_BYTES / size_of::<IpcSegmentInfo>();
 
 pub const IPC_COLOR_MAX_COUNT: usize = 1024;

--- a/docker4bots/spn_rust_base/spn_rust_framework/src/main.rs
+++ b/docker4bots/spn_rust_base/spn_rust_framework/src/main.rs
@@ -26,120 +26,118 @@ use uds::UnixSeqpacketConn;
 use std::mem::{size_of, transmute};
 
 pub mod api;
-use api::ipc::{IpcResponse, IpcResponseType, IpcRequestType};
+use api::ipc::{IpcRequestType, IpcResponse, IpcResponseType};
 
 pub mod usercode;
 use usercode::{init, step};
 
-static SPN_SHM_FILE:    &str = "/spnshm/shm";
+static SPN_SHM_FILE: &str = "/spnshm/shm";
 static SPN_SOCKET_FILE: &str = "/spnshm/socket";
 
-fn mainloop(mut api: api::Api, socket: UnixSeqpacketConn)
-{
-	let mut running = true;
-	let mut rxbuf = [0u8; size_of::<api::ipc::IpcRequest>()];
+fn mainloop(mut api: api::Api, socket: UnixSeqpacketConn) {
+    let mut running = true;
+    let mut rxbuf = [0u8; size_of::<api::ipc::IpcRequest>()];
 
-	while running {
-		// receive messages from the Gameserver
-		let (len, _truncated) = socket.recv(&mut rxbuf).unwrap();
+    while running {
+        // receive messages from the Gameserver
+        let (len, _truncated) = socket.recv(&mut rxbuf).unwrap();
 
-		// length check
-		if len == 0 {
-			println!("Socket connection terminated by server.");
-			break;
-		} else if len < rxbuf.len() {
-			println!("Error: packet is too short! Expected {} bytes, but received only {}. Packet ignored.",
+        // length check
+        if len == 0 {
+            println!("Socket connection terminated by server.");
+            break;
+        } else if len < rxbuf.len() {
+            println!("Error: packet is too short! Expected {} bytes, but received only {}. Packet ignored.",
 			         rxbuf.len(), len);
-			continue;
-		}
+            continue;
+        }
 
-		// check whether the data contains a valid enum value
-		let request_value = unsafe {
-			*transmute::<*const u8, *const u32>(rxbuf.as_ptr())
-		};
+        // check whether the data contains a valid enum value
+        let request_value = unsafe { *transmute::<*const u8, *const u32>(rxbuf.as_ptr()) };
 
-		let request_type;
+        let request_type;
 
-		match api::ipc::IpcRequestType::from_u32(request_value) {
-			Some(x) => request_type = x,
-			None => {
-				println!("Request type cannot be decoded!");
-				continue;
-			}
-		}
+        match api::ipc::IpcRequestType::from_u32(request_value) {
+            Some(x) => request_type = x,
+            None => {
+                println!("Request type cannot be decoded!");
+                continue;
+            }
+        }
 
-		/*
-		// reinterpret the received data as struct IpcRequest
-		let request: &api::ipc::IpcRequest = unsafe {
-			& *transmute::<*const u8, *const api::ipc::IpcRequest>(rxbuf.as_ptr())
-		};
-		*/
+        /*
+        // reinterpret the received data as struct IpcRequest
+        let request: &api::ipc::IpcRequest = unsafe {
+            & *transmute::<*const u8, *const api::ipc::IpcRequest>(rxbuf.as_ptr())
+        };
+        */
 
-		let angle: f32;
-		let boost: bool;
+        let angle: f32;
+        let boost: bool;
 
-		// execute the user functions corresponding to the request type
-		match request_type {
-			IpcRequestType::Init => {
-				running = init(&mut api);
-				angle = 0.0;
-				boost = false;
-			},
-			IpcRequestType::Step => {
-				// unfortunately, destructuring is not stable yet.
-				let (tmp_running, tmp_angle, tmp_boost) = step(&mut api);
-				running = tmp_running;
-				angle = tmp_angle;
-				boost = tmp_boost;
-			},
-		}
+        // execute the user functions corresponding to the request type
+        match request_type {
+            IpcRequestType::Init => {
+                running = init(&mut api);
+                angle = 0.0;
+                boost = false;
+            }
+            IpcRequestType::Step => {
+                // unfortunately, destructuring is not stable yet.
+                let (tmp_running, tmp_angle, tmp_boost) = step(&mut api);
+                running = tmp_running;
+                angle = tmp_angle;
+                boost = tmp_boost;
+            }
+        }
 
-		// build the response structure
-		let response = IpcResponse {
-			response_type: match running {
-				true => IpcResponseType::Ok,
-				false => IpcResponseType::Error,
-			},
-			data: api::ipc::ResponseData {
-				step: api::ipc::IpcStepResponse {
-					delta_angle: angle,
-					boost: boost
-				}
-			}
-		};
+        // build the response structure
+        let response = IpcResponse {
+            response_type: match running {
+                true => IpcResponseType::Ok,
+                false => IpcResponseType::Error,
+            },
+            data: api::ipc::ResponseData {
+                step: api::ipc::IpcStepResponse {
+                    delta_angle: angle,
+                    boost: boost,
+                },
+            },
+        };
 
-		// reinterpret the response structure as byte array
-		let txdata: &[u8] = unsafe {
-			std::slice::from_raw_parts(
-				(&response as *const IpcResponse) as *const u8,
-				std::mem::size_of::<IpcResponse>())
-		};
+        // reinterpret the response structure as byte array
+        let txdata: &[u8] = unsafe {
+            std::slice::from_raw_parts(
+                (&response as *const IpcResponse) as *const u8,
+                std::mem::size_of::<IpcResponse>(),
+            )
+        };
 
-		// send the result packet
-		socket.send(txdata).unwrap();
-	}
+        // send the result packet
+        socket.send(txdata).unwrap();
+    }
 }
 
 fn main() {
-	/*
-	// For cross-checking structure layout between different programming languages.
-	println!("sizeof(IpcSelfInfo)     = {:8}", size_of::<api::ipc::IpcSelfInfo>());
-	println!("sizeof(IpcServerConfig) = {:8}", size_of::<api::ipc::IpcServerConfig>());
-	println!("sizeof(IpcFoodInfo)     = {:8}", size_of::<api::ipc::IpcFoodInfo>());
-	println!("sizeof(IpcBotInfo)      = {:8}", size_of::<api::ipc::IpcBotInfo>());
-	println!("sizeof(IpcSegmentInfo)  = {:8}", size_of::<api::ipc::IpcSegmentInfo>());
-	println!("sizeof(IpcColor)        = {:8}", size_of::<api::ipc::IpcColor>());
-	println!("sizeof(IpcSharedMemory) = {:8}", size_of::<api::ipc::IpcSharedMemory>());
-	println!("sizeof(IpcRequest)      = {:8}", size_of::<api::ipc::IpcRequest>());
-	println!("sizeof(IpcStepResponse) = {:8}", size_of::<api::ipc::IpcStepResponse>());
-	println!("sizeof(IpcResponse)     = {:8}", size_of::<api::ipc::IpcResponse>());
-	println!("sizeof(bool)            = {:8}", size_of::<bool>());
-	return;
-	*/
+    /*
+    // For cross-checking structure layout between different programming languages.
+    println!("sizeof(IpcSelfInfo)     = {:8}", size_of::<api::ipc::IpcSelfInfo>());
+    println!("sizeof(IpcServerConfig) = {:8}", size_of::<api::ipc::IpcServerConfig>());
+    println!("sizeof(IpcFoodInfo)     = {:8}", size_of::<api::ipc::IpcFoodInfo>());
+    println!("sizeof(IpcBotInfo)      = {:8}", size_of::<api::ipc::IpcBotInfo>());
+    println!("sizeof(IpcSegmentInfo)  = {:8}", size_of::<api::ipc::IpcSegmentInfo>());
+    println!("sizeof(IpcColor)        = {:8}", size_of::<api::ipc::IpcColor>());
+    println!("sizeof(IpcSharedMemory) = {:8}", size_of::<api::ipc::IpcSharedMemory>());
+    println!("sizeof(IpcRequest)      = {:8}", size_of::<api::ipc::IpcRequest>());
+    println!("sizeof(IpcStepResponse) = {:8}", size_of::<api::ipc::IpcStepResponse>());
+    println!("sizeof(IpcResponse)     = {:8}", size_of::<api::ipc::IpcResponse>());
+    println!("sizeof(bool)            = {:8}", size_of::<bool>());
+    return;
+    */
 
-	let a = api::Api::new(SPN_SHM_FILE).unwrap();
+    let a = api::Api::new(SPN_SHM_FILE).unwrap();
 
-	let conn = UnixSeqpacketConn::connect(SPN_SOCKET_FILE).unwrap();
+    let conn = UnixSeqpacketConn::connect(SPN_SOCKET_FILE).unwrap();
 
-	mainloop(a, conn);
+    mainloop(a, conn);
 }

--- a/docker4bots/spn_rust_base/spn_rust_framework/src/main.rs
+++ b/docker4bots/spn_rust_base/spn_rust_framework/src/main.rs
@@ -55,15 +55,13 @@ fn mainloop(mut api: api::Api, socket: UnixSeqpacketConn) {
         // check whether the data contains a valid enum value
         let request_value = unsafe { *transmute::<*const u8, *const u32>(rxbuf.as_ptr()) };
 
-        let request_type;
-
-        match api::ipc::IpcRequestType::from_u32(request_value) {
-            Some(x) => request_type = x,
+        let request_type = match api::ipc::IpcRequestType::from_u32(request_value) {
+            Some(x) => x,
             None => {
                 println!("Request type cannot be decoded!");
                 continue;
             }
-        }
+        };
 
         /*
         // reinterpret the received data as struct IpcRequest
@@ -100,7 +98,7 @@ fn mainloop(mut api: api::Api, socket: UnixSeqpacketConn) {
             data: api::ipc::ResponseData {
                 step: api::ipc::IpcStepResponse {
                     delta_angle: angle,
-                    boost: boost,
+                    boost,
                 },
             },
         };

--- a/docker4bots/spn_rust_base/spn_rust_framework/src/usercode.rs
+++ b/docker4bots/spn_rust_base/spn_rust_framework/src/usercode.rs
@@ -6,20 +6,19 @@ use crate::api;
  * This is your bot's startup function. Here you can set your snake's colors,
  * set up persistent variables, etc.
  */
-pub fn init(api: &mut api::Api) -> bool
-{
-	// remove the default color
-	api.clear_colors();
+pub fn init(api: &mut api::Api) -> bool {
+    // remove the default color
+    api.clear_colors();
 
-	// I'm green!
-	api.add_color(40, 255, 0);
-	api.add_color(20, 128, 0);
-	api.add_color(10,  64, 0);
-	api.add_color(20, 128, 0);
+    // I'm green!
+    api.add_color(40, 255, 0);
+    api.add_color(20, 128, 0);
+    api.add_color(10, 64, 0);
+    api.add_color(20, 128, 0);
 
-	// indicate successful startup. If anything goes wrong,
-	// return false and we'll clean you up.
-	return true;
+    // indicate successful startup. If anything goes wrong,
+    // return false and we'll clean you up.
+    return true;
 }
 
 /**
@@ -39,27 +38,26 @@ pub fn init(api: &mut api::Api) -> bool
  * - boost (bool):    When set to true, your snake will get a speed boost, but
  *                    this will cost some of the snake’s mass.
  */
-pub fn step(api: &mut api::Api) -> (bool, f32, bool)
-{
-	// let's start by moving in a large circle. Please note that all angles are
-	// represented in radians, where -π to +π is a full circle.
-	let angle: f32 = 0.001;
+pub fn step(api: &mut api::Api) -> (bool, f32, bool) {
+    // let's start by moving in a large circle. Please note that all angles are
+    // represented in radians, where -π to +π is a full circle.
+    let angle: f32 = 0.001;
 
-	// check for other snakes
-	let segments = api.get_segments();
+    // check for other snakes
+    let segments = api.get_segments();
 
-	for seg in segments {
-		if !seg.is_self && seg.dist < 20.0 {
-			// you can send log messages to your browser or any other viewer with the
-			// appropriate Viewer Key.
-			api.log("Oh no, I'm going to die!");
-			break;
-		}
-	}
+    for seg in segments {
+        if !seg.is_self && seg.dist < 20.0 {
+            // you can send log messages to your browser or any other viewer with the
+            // appropriate Viewer Key.
+            api.log("Oh no, I'm going to die!");
+            break;
+        }
+    }
 
-	// finding food is quite similar
+    // finding food is quite similar
 
-	// Signal that everything is ok. Return false here if anything goes wrong but
-	// you want to shut down cleanly.
-	return (true, angle, false); // continue, angle, boost
+    // Signal that everything is ok. Return false here if anything goes wrong but
+    // you want to shut down cleanly.
+    return (true, angle, false); // continue, angle, boost
 }

--- a/docker4bots/spn_rust_base/spn_rust_framework/src/usercode.rs
+++ b/docker4bots/spn_rust_base/spn_rust_framework/src/usercode.rs
@@ -49,8 +49,8 @@ pub fn step(api: &mut api::Api) -> (bool, f32, bool) {
     for seg in segments {
         if !seg.is_self && seg.dist < 20.0 {
             // you can send log messages to your browser or any other viewer with the
-            // appropriate Viewer Key. It's okay for the call to fail, e.g. when the
-            // rate limit is reached
+            // appropriate Viewer Key. It's okay for the call to fail,
+            // e.g. when the log memory is full
             let _ = api.log("Oh no, I'm going to die!");
             break;
         }

--- a/docker4bots/spn_rust_base/spn_rust_framework/src/usercode.rs
+++ b/docker4bots/spn_rust_base/spn_rust_framework/src/usercode.rs
@@ -18,7 +18,7 @@ pub fn init(api: &mut api::Api) -> bool {
 
     // indicate successful startup. If anything goes wrong,
     // return false and we'll clean you up.
-    return true;
+    true
 }
 
 /**
@@ -59,5 +59,5 @@ pub fn step(api: &mut api::Api) -> (bool, f32, bool) {
 
     // Signal that everything is ok. Return false here if anything goes wrong but
     // you want to shut down cleanly.
-    return (true, angle, false); // continue, angle, boost
+    (true, angle, false) // continue, angle, boost
 }

--- a/docker4bots/spn_rust_base/spn_rust_framework/src/usercode.rs
+++ b/docker4bots/spn_rust_base/spn_rust_framework/src/usercode.rs
@@ -49,8 +49,9 @@ pub fn step(api: &mut api::Api) -> (bool, f32, bool) {
     for seg in segments {
         if !seg.is_self && seg.dist < 20.0 {
             // you can send log messages to your browser or any other viewer with the
-            // appropriate Viewer Key.
-            api.log("Oh no, I'm going to die!");
+            // appropriate Viewer Key. It's okay for the call to fail, e.g. when the
+            // rate limit is reached
+            let _ = api.log("Oh no, I'm going to die!");
             break;
         }
     }


### PR DESCRIPTION
Hi SPN team,

thanks for adding Rust support! In Rust there are some standard tools to [format code](https://github.com/rust-lang/rustfmt) and [check code style](https://github.com/rust-lang/rust-clippy). I did let them run and fixed the warnings.
I suggest to review the commits individually, as the rust formatter did change quite some lines...

1. The first commit just let `cargo fmt` run.
2. The second commit fixed all the `cargo clippy` warnings
3. The last commit did improve the error handling. This introduces a breaking change in the API as the fn `log` now returns `Result<(), String>` instead of a `bool` previously. This allows us to give the caller information on what happened, e.g. rate limit was reached. It also enables us to use error-handling code such as `.ok_or_else()?`.
In general we pass `String` as the Error variant around, this can be improved by using dedicated error handling crates but I think this is fine for this rather "small" codebase.
As an example you can see the difference when running `cargo r`: Previously it was
`thread 'main' panicked at 'called Result::unwrap() on an Err value: Os { code: 2, kind: NotFound, message: "No such file or directory" }', src/api.rs:44:32`, now it's `Error: "Could not open shared memory file /spnshm/shm: No such file or directory (os error 2)"`

Hope you are interested in this PR, but i can also understand if you don't want to merge it. Using rust-fmt and clippy is kind of industry-standard in the Rust universe, so it might make things easier to read for others ;)

Cheers,
Sebastian
